### PR TITLE
[recorder] Fix incorrect attribute enum value capability query

### DIFF
--- a/meta/sai_serialize.h
+++ b/meta/sai_serialize.h
@@ -153,6 +153,11 @@ std::string sai_serialize_enum(
         _In_ const int32_t value,
         _In_ const sai_enum_metadata_t* meta);
 
+std::string sai_serialize_enum_list(
+        _In_ const sai_s32_list_t& list,
+        _In_ const sai_enum_metadata_t* meta,
+        _In_ bool countOnly);
+
 std::string sai_serialize_number(
         _In_ uint32_t number,
         _In_ bool hex = false);


### PR DESCRIPTION
Recorder was assuming that enum value capability query is executed for an
attribute that has a value type of a s32 list.

When querying SAI_DEBUG_COUNTER_ATTR_TYPE using
sai_query_attribute_enum_values_capability a warning is printed in
syslog: "enum value 4 not found in enum sai_debug_counter_type".

This happens because SAI_DEBUG_COUNTER_ATTR_TYPE attrvaluetype is int32
(enum value) and sai_s32_list_t structure was casted to int32. Since we
initialize sai_s32_list with .count = 4 (the number of values in
sai_debug_counter_type_t enum) value 4 is printed in the syslog.

Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>