### PR TITLE
[configure.ac] implement SAI API version check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,29 @@ AC_SUBST(CXXFLAGS_COMMON)
 
 AC_SUBST(SAIINC, "-I\$(top_srcdir)/SAI/inc -I\$(top_srcdir)/SAI/experimental -I\$(top_srcdir)/SAI/meta")
 
+AM_COND_IF([SYNCD], [
+AM_COND_IF([SAIVS], [], [
+SAVED_FLAGS="$CXXFLAGS"
+CXXFLAGS="-lsai -I$srcdir/SAI/inc -I$srcdir/SAI/experimental -I$srcdir/SAI/meta"
+AC_MSG_CHECKING([SAI headers API version and library version check])
+AC_TRY_RUN([
+extern "C" {
+#include <sai.h>
+}
+int main() {
+    sai_api_version_t version;
+    if (SAI_STATUS_SUCCESS != sai_query_api_version(&version))
+    {
+        return 1;
+    }
+    return (version != SAI_API_VERSION);
+}],
+[AC_MSG_RESULT(ok)],
+[AC_MSG_RESULT(failed)
+AC_MSG_ERROR("SAI headers API version and library version mismatch")])
+CXXFLAGS="$SAVED_FLAGS"
+])])
+
 AC_OUTPUT(Makefile
           meta/Makefile
           lib/Makefile

--- a/vslib/sai_vs_interfacequery.cpp
+++ b/vslib/sai_vs_interfacequery.cpp
@@ -192,3 +192,12 @@ sai_status_t sai_query_stats_capability(
 
     return vs_sai->queryStatsCapability(switch_id, object_type, stats_capability);
 }
+
+sai_status_t sai_query_api_version(
+        _Out_ sai_api_version_t *version)
+{
+    SWSS_LOG_ENTER();
+
+    *version = SAI_API_VERSION;
+    return SAI_STATUS_SUCCESS;
+}


### PR DESCRIPTION
Signed-off-by: Stepan Blyschak <stepanb@nvidia.com>

The motivation for this change is described in the proposal ```https://github.com/Azure/SONiC/pull/935``` and proposal in SAI ```https://github.com/opencomputeproject/SAI/pull/1404```
NOTE: Requires to update SAI once ```https://github.com/opencomputeproject/SAI/pull/1404``` is in.