### PR TITLE
[syncd] Support PORT and INGRESS_PRIORITY_GROUP bulk set in INIT_VIEW mode

### DIFF
--- a/syncd/tests/TestSyncdBrcm.cpp
+++ b/syncd/tests/TestSyncdBrcm.cpp
@@ -506,7 +506,18 @@ TEST_F(SyncdBrcmTest, nexthopBulkTest)
     }
 }
 
-TEST_F(SyncdBrcmTest, portBufferBulkSet)
+enum class SyncdView
+{
+    Init,
+    Apply,
+};
+
+class SyncdBrcmTestInView : public SyncdBrcmTest,
+                            public ::testing::WithParamInterface<SyncdView>
+{
+};
+
+TEST_P(SyncdBrcmTestInView, portBufferBulkSet)
 {
     sai_object_id_t switchId;
     sai_attribute_t attrs[1];
@@ -542,6 +553,33 @@ TEST_F(SyncdBrcmTest, portBufferBulkSet)
 
     status = m_sairedis->create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, attrs);
     ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+    if (GetParam() == SyncdView::Init)
+    {
+        // apply view
+
+        attrs[0].id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
+        attrs[0].value.s32 = SAI_REDIS_NOTIFY_SYNCD_APPLY_VIEW;
+
+        status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, attrs);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+        // init view
+
+        attrs[0].id = SAI_REDIS_SWITCH_ATTR_NOTIFY_SYNCD;
+        attrs[0].value.s32 = SAI_REDIS_NOTIFY_SYNCD_INIT_VIEW;
+
+        status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, attrs);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+
+        // create switch
+
+        attrs[0].id = SAI_SWITCH_ATTR_INIT_SWITCH;
+        attrs[0].value.booldata = true;
+
+        status = m_sairedis->create(SAI_OBJECT_TYPE_SWITCH, &switchId, SAI_NULL_OBJECT_ID, 1, attrs);
+        ASSERT_EQ(status, SAI_STATUS_SUCCESS);
+    }
 
     attrs[0].id = SAI_SWITCH_ATTR_PORT_NUMBER;
     status = m_sairedis->get(SAI_OBJECT_TYPE_SWITCH, switchId, 1, attrs);
@@ -684,3 +722,7 @@ TEST_F(SyncdBrcmTest, portBufferBulkSet)
     status = m_sairedis->set(SAI_OBJECT_TYPE_SWITCH, SAI_NULL_OBJECT_ID, attrs);
     ASSERT_EQ(status, SAI_STATUS_SUCCESS);
 }
+
+INSTANTIATE_TEST_SUITE_P(bulkTestsInSyncdViews,
+                         SyncdBrcmTestInView,
+                         testing::Values(SyncdView::Apply, SyncdView::Init));


### PR DESCRIPTION
Fix code for bulk quad event handling in INIT_VIEW - relaxed the condition for PORT and INGRESS_PRIORITY_GROUP objects for SET API. Fixed an issue where objects passed to bulk SET API are considered to be created in INIT_VIEW.