### PR TITLE
[syncd] Add support for redis pipeline to RedisClient

### DIFF
--- a/saiasiccmp/Makefile.am
+++ b/saiasiccmp/Makefile.am
@@ -19,7 +19,7 @@ saiasiccmp_SOURCES = main.cpp
 saiasiccmp_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 saiasiccmp_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
 saiasiccmp_LDADD = libAsicCmp.a \
-				   -ldl -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq \
-				   $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a $(CODE_COVERAGE_LIBS)
+				   -ldl -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq \
+				   $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a -lhiredis -lswsscommon $(CODE_COVERAGE_LIBS)
 
 TESTS = test.sh

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -2161,6 +2161,8 @@ sai_status_t Syncd::processBulkOid(
 {
     SWSS_LOG_ENTER();
 
+    RedisBufferedScope bufferedScope{m_client.get()};
+
     auto info = sai_metadata_get_object_type_info(objectType);
 
     if (info->isnonobjectid)


### PR DESCRIPTION
Implement support for redis pipeline to speed up bulk operations. I.e. when new objects are discovered by syncd during GET operation 3 redis set commands (1 set to VIDTORID, 1 set to RIDTOVID, 1 set to ASIC_STATE table) are done per object. In local test with bulk get I observe 40% speedup.