### PR TITLE
Revert "[nvidia] Skip SAI discovery on ports (#1416)"

### DIFF
--- a/syncd/Makefile.am
+++ b/syncd/Makefile.am
@@ -83,10 +83,6 @@ if SONIC_ASIC_PLATFORM_BROADCOM
 libSyncd_a_CXXFLAGS += -DMDIO_ACCESS_USE_NPU
 endif
 
-if SONIC_ASIC_PLATFORM_MELLANOX
-libSyncd_a_CPPFLAGS += -DSKIP_SAI_PORT_DISCOVERY
-endif
-
 libSyncdRequestShutdown_a_SOURCES = \
 									RequestShutdown.cpp \
 									RequestShutdownCommandLineOptions.cpp \

--- a/syncd/SaiDiscovery.cpp
+++ b/syncd/SaiDiscovery.cpp
@@ -112,13 +112,6 @@ void SaiDiscovery::discover(
         discovered.insert(rid);
     }
 
-#ifdef SKIP_SAI_PORT_DISCOVERY
-    if (ot == SAI_OBJECT_TYPE_PORT)
-    {
-        return;
-    }
-#endif
-
     const sai_object_type_info_t *info = sai_metadata_get_object_type_info(ot);
 
     /*

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -231,10 +231,6 @@ Syncd::Syncd(
 
     m_breakConfig = BreakConfigParser::parseBreakConfig(m_commandLineOptions->m_breakConfig);
 
-#ifdef SKIP_SAI_PORT_DISCOVERY
-    SWSS_LOG_WARN("SAI discovery is skipped on ports");
-#endif
-
     SWSS_LOG_NOTICE("syncd started");
 }
 


### PR DESCRIPTION
This reverts commit 0f3b34eb50737a96a1dcdc691e64776c26ae37b3.