### PR TITLE
[202412_RC][discovery] speed up sai discovery on ports (#1559)

### DIFF
--- a/lib/OidIndexGenerator.h
+++ b/lib/OidIndexGenerator.h
@@ -2,6 +2,9 @@
 
 #include <stdint.h>
 
+#include <swss/sal.h>
+#include <vector>
+
 namespace sairedis
 {
     class OidIndexGenerator
@@ -15,6 +18,9 @@ namespace sairedis
         public:
 
             virtual uint64_t increment() = 0;
+
+            virtual std::vector<uint64_t> incrementBy(
+                _In_ uint64_t count) = 0;
 
             virtual void reset() = 0;
     };

--- a/lib/RedisVidIndexGenerator.h
+++ b/lib/RedisVidIndexGenerator.h
@@ -23,6 +23,8 @@ namespace sairedis
         public:
 
             virtual uint64_t increment() override;
+            virtual std::vector<uint64_t> incrementBy(
+                _In_ uint64_t count) override;
 
             virtual void reset() override;
 

--- a/lib/VirtualObjectIdManager.h
+++ b/lib/VirtualObjectIdManager.h
@@ -68,6 +68,17 @@ namespace sairedis
                     _In_ sai_object_id_t switchId);
 
             /**
+             * @brief Allocate multiple object ids on a given switch.
+             *
+             * Throws when object type is switch.
+             */
+            void allocateNewObjectIds(
+                    _In_ sai_object_id_t switchId,
+                    _In_ size_t count,
+                    _In_ const sai_object_type_t* objectTypes,
+                    _Out_ sai_object_id_t* oids) const;
+
+            /**
              * @brief Allocate new switch object id.
              */
             sai_object_id_t allocateNewSwitchObjectId(

--- a/meta/NumberOidIndexGenerator.cpp
+++ b/meta/NumberOidIndexGenerator.cpp
@@ -18,6 +18,22 @@ uint64_t NumberOidIndexGenerator::increment()
     return ++m_index;
 }
 
+std::vector<uint64_t> NumberOidIndexGenerator::incrementBy(
+    _In_ uint64_t count)
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<uint64_t> result;
+    result.reserve(static_cast<size_t>(count));
+
+    for (uint64_t i = 0; i < count; ++i)
+    {
+        result.push_back(++m_index);
+    }
+
+    return result;
+}
+
 void NumberOidIndexGenerator::reset()
 {
     SWSS_LOG_ENTER();

--- a/meta/NumberOidIndexGenerator.h
+++ b/meta/NumberOidIndexGenerator.h
@@ -17,6 +17,8 @@ namespace saimeta
         public:
 
             virtual uint64_t increment() override;
+            virtual std::vector<uint64_t> incrementBy(
+                _In_ uint64_t count) override;
 
             virtual void reset() override;
 

--- a/saiasiccmp/Makefile.am
+++ b/saiasiccmp/Makefile.am
@@ -19,7 +19,7 @@ saiasiccmp_SOURCES = main.cpp
 saiasiccmp_CPPFLAGS = $(CODE_COVERAGE_CPPFLAGS)
 saiasiccmp_CXXFLAGS = $(DBGFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS_COMMON) $(CODE_COVERAGE_CXXFLAGS)
 saiasiccmp_LDADD = libAsicCmp.a \
-				   -ldl -lhiredis -lswsscommon -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq \
-				   $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a $(CODE_COVERAGE_LIBS)
+				   -ldl -lpthread -L$(top_srcdir)/meta/.libs -lsaimetadata -lsaimeta -lzmq \
+				   $(top_srcdir)/syncd/libSyncd.a $(top_srcdir)/lib/libSaiRedis.a -lhiredis -lswsscommon $(CODE_COVERAGE_LIBS)
 
 TESTS = test.sh

--- a/saiasiccmp/SaiSwitchAsic.cpp
+++ b/saiasiccmp/SaiSwitchAsic.cpp
@@ -270,9 +270,9 @@ std::set<sai_object_id_t> SaiSwitchAsic::getWarmBootDiscoveredVids() const
     return {};
 }
 
-void SaiSwitchAsic::onPostPortCreate(
-        _In_ sai_object_id_t port_rid,
-        _In_ sai_object_id_t port_vid)
+void SaiSwitchAsic::onPostPortsCreate(
+        _In_ size_t count,
+        _In_ const sai_object_id_t* port_rids)
 {
     SWSS_LOG_ENTER();
 

--- a/saiasiccmp/SaiSwitchAsic.h
+++ b/saiasiccmp/SaiSwitchAsic.h
@@ -64,9 +64,9 @@ namespace saiasiccmp
 
             virtual std::set<sai_object_id_t> getWarmBootDiscoveredVids() const override;
 
-            virtual void onPostPortCreate(
-                    _In_ sai_object_id_t port_rid,
-                    _In_ sai_object_id_t port_vid) override;
+            virtual void onPostPortsCreate(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* port_rids) override;
 
             virtual void postPortRemove(
                     _In_ sai_object_id_t portRid) override;

--- a/syncd/RedisClient.h
+++ b/syncd/RedisClient.h
@@ -48,6 +48,10 @@ namespace syncd
             void setDummyAsicStateObject(
                     _In_ sai_object_id_t objectVid);
 
+            void setDummyAsicStateObjects(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* objectVids);
+
             void saveColdBootDiscoveredVids(
                     _In_ sai_object_id_t switchVid,
                     _In_ const std::set<sai_object_id_t>& coldVids);
@@ -128,11 +132,21 @@ namespace syncd
                     _In_ sai_object_id_t vid,
                     _In_ sai_object_id_t rid);
 
+            void insertVidsAndRids(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* vids,
+                    _In_ const sai_object_id_t* rids);
+
             sai_object_id_t getVidForRid(
                     _In_ sai_object_id_t rid);
 
             sai_object_id_t getRidForVid(
                     _In_ sai_object_id_t vid);
+
+            void getVidsForRids(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* rids,
+                    _Out_ sai_object_id_t* vids);
 
             void removeAsicStateTable();
 

--- a/syncd/SaiDiscovery.h
+++ b/syncd/SaiDiscovery.h
@@ -9,8 +9,11 @@
 #include <map>
 #include <unordered_map>
 
+#include "swss/logger.h"
+
 namespace syncd
 {
+
     class SaiDiscovery
     {
         public:
@@ -19,8 +22,22 @@ namespace syncd
 
         public:
 
+            enum Flags
+            {
+                None = 0,
+                SkipDefaultEmptyAttributes = 1 << 0,
+            };
+
+            friend inline Flags operator|(Flags a, Flags b)
+            {
+                SWSS_LOG_ENTER();
+
+                return static_cast<Flags>(static_cast<std::underlying_type_t<Flags>>(a) | static_cast<std::underlying_type_t<Flags>>(b));
+            }
+
             SaiDiscovery(
-                    _In_ std::shared_ptr<sairedis::SaiInterface> sai);
+                    _In_ std::shared_ptr<sairedis::SaiInterface> sai,
+                    _In_ Flags flags = Flags::None);
 
             virtual ~SaiDiscovery();
 
@@ -28,6 +45,10 @@ namespace syncd
 
             std::set<sai_object_id_t> discover(
                     _In_ sai_object_id_t rid);
+
+            std::set<sai_object_id_t> discover(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* rids);
 
             const DefaultOidMap& getDefaultOidMap() const;
 
@@ -61,6 +82,8 @@ namespace syncd
         private:
 
             std::shared_ptr<sairedis::SaiInterface> m_sai;
+
+            Flags m_flags;
 
             DefaultOidMap m_defaultOidMap;
 

--- a/syncd/SaiSwitch.cpp
+++ b/syncd/SaiSwitch.cpp
@@ -337,6 +337,19 @@ void SaiSwitch::redisSetDummyAsicStateForRealObjectId(
     m_client->setDummyAsicStateObject(vid);
 }
 
+void SaiSwitch::redisSetDummyAsicStateForRealObjectIds(
+        _In_ size_t count,
+        _In_ const sai_object_id_t* rids) const
+{
+    SWSS_LOG_ENTER();
+
+    std::vector<sai_object_id_t> vids(count);
+
+    m_translator->translateRidsToVids(m_switch_vid, count, rids, vids.data());
+
+    m_client->setDummyAsicStateObjects(count, vids.data());
+}
+
 std::string SaiSwitch::getHardwareInfo() const
 {
     SWSS_LOG_ENTER();
@@ -946,15 +959,17 @@ void SaiSwitch::redisUpdatePortLaneMap(
             sai_serialize_object_id(port_rid).c_str());
 }
 
-void SaiSwitch::onPostPortCreate(
-        _In_ sai_object_id_t port_rid,
-        _In_ sai_object_id_t port_vid)
+void SaiSwitch::onPostPortsCreate(
+        _In_ size_t count,
+        _In_ const sai_object_id_t* port_rids)
 {
     SWSS_LOG_ENTER();
 
-    SaiDiscovery sd(m_vendorSai);
+    SWSS_LOG_TIMER("discovering objects after creating ports");
 
-    auto discovered = sd.discover(port_rid);
+    SaiDiscovery sd(m_vendorSai, SaiDiscovery::Flags::SkipDefaultEmptyAttributes);
+
+    auto discovered = sd.discover(count, port_rids);
 
     auto defaultOidMap = sd.getDefaultOidMap();
 
@@ -968,29 +983,26 @@ void SaiSwitch::onPostPortCreate(
         }
     }
 
-    SWSS_LOG_NOTICE("discovered %zu new objects (including port) after creating port VID: %s",
-            discovered.size(),
-            sai_serialize_object_id(port_vid).c_str());
+    SWSS_LOG_NOTICE("discovered %zu new objects (including port) after creating %zu ports",
+            discovered.size(), count);
 
     m_discovered_rids.insert(discovered.begin(), discovered.end());
 
-    SWSS_LOG_NOTICE("putting ALL new discovered objects to redis for port %s",
-            sai_serialize_object_id(port_vid).c_str());
+    std::vector<sai_object_id_t> rids{discovered.begin(), discovered.end()};
 
-    for (sai_object_id_t rid: discovered)
+    /*
+     * We also could think of optimizing this since it's one command
+     * per rid in a redis pipeline, and probably this should be ATOMIC.
+     *
+     * NOTE: We are also storing read only object's here, like default
+     * virtual router, CPU, default trap group, etc.
+     */
+    redisSetDummyAsicStateForRealObjectIds(rids.size(), rids.data());
+
+    for (size_t idx = 0; idx < count; idx++)
     {
-        /*
-         * We also could thing of optimizing this since it's one call to redis
-         * per rid, and probably this should be ATOMIC.
-         *
-         * NOTE: We are also storing read only object's here, like default
-         * virtual router, CPU, default trap group, etc.
-         */
-
-        redisSetDummyAsicStateForRealObjectId(rid);
+        redisUpdatePortLaneMap(port_rids[idx]);
     }
-
-    redisUpdatePortLaneMap(port_rid);
 }
 
 bool SaiSwitch::isWarmBoot() const

--- a/syncd/SaiSwitch.h
+++ b/syncd/SaiSwitch.h
@@ -182,13 +182,13 @@ namespace syncd
             /**
              * @brief On post port create.
              *
-             * Performs actions needed after port creation. Will discover new
-             * queues, ipgs and scheduler groups that belong to new created port,
+             * Performs actions needed after ports creation. Will discover new
+             * queues, ipgs and scheduler groups that belong to new created ports,
              * and updated ASIC DB accordingly.
              */
-            virtual void onPostPortCreate(
-                    _In_ sai_object_id_t port_rid,
-                    _In_ sai_object_id_t port_vid) override;
+            virtual void onPostPortsCreate(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* port_rids) override;
 
             /**
              * @brief Post port remove.
@@ -242,6 +242,10 @@ namespace syncd
 
             void redisSetDummyAsicStateForRealObjectId(
                     _In_ sai_object_id_t rid) const;
+
+            void redisSetDummyAsicStateForRealObjectIds(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* rids) const;
 
             /**
              * @brief Put cold boot discovered VIDs to redis DB.

--- a/syncd/SaiSwitchInterface.h
+++ b/syncd/SaiSwitchInterface.h
@@ -87,9 +87,9 @@ namespace syncd
 
             virtual std::set<sai_object_id_t> getWarmBootNewDiscoveredVids();
 
-            virtual void onPostPortCreate(
-                    _In_ sai_object_id_t port_rid,
-                    _In_ sai_object_id_t port_vid) = 0;
+            virtual void onPostPortsCreate(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* port_rids) = 0;
 
             virtual void postPortRemove(
                     _In_ sai_object_id_t portRid) = 0;

--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -2159,24 +2159,28 @@ sai_status_t Syncd::processBulkOidCreate(
     }
 
     /*
-     * Object was created so new object id was generated we need to save
-     * virtual id's to redis db.
+     * Create vectors for successfully created objects only, since objectRids/Vids
+     * contain both successful and failed entries. Only store successful mappings
+     * in Redis.
      */
+    std::vector<sai_object_id_t> createdRids, createdVids;
+    createdRids.reserve(object_count);
+    createdVids.reserve(object_count);
+
     for (size_t idx = 0; idx < object_count; idx++)
     {
         if (statuses[idx] == SAI_STATUS_SUCCESS)
         {
-            m_translator->insertRidAndVid(objectRids[idx], objectVids[idx]);
-
-            SWSS_LOG_INFO("saved VID %s to RID %s",
-                    sai_serialize_object_id(objectVids[idx]).c_str(),
-                    sai_serialize_object_id(objectRids[idx]).c_str());
-
-            if (objectType == SAI_OBJECT_TYPE_PORT)
-            {
-                m_switches.at(switchVid)->onPostPortCreate(objectRids[idx], objectVids[idx]);
-            }
+            createdRids.push_back(objectRids[idx]);
+            createdVids.push_back(objectVids[idx]);
         }
+    }
+
+    m_translator->insertRidsAndVids(createdRids.size(), createdRids.data(), createdVids.data());
+
+    if (objectType == SAI_OBJECT_TYPE_PORT)
+    {
+        m_switches.at(switchVid)->onPostPortsCreate(createdRids.size(), createdRids.data());
     }
 
     return status;
@@ -3481,7 +3485,7 @@ sai_status_t Syncd::processOidCreate(
 
         if (objectType == SAI_OBJECT_TYPE_PORT)
         {
-            m_switches.at(switchVid)->onPostPortCreate(objectRid, objectVid);
+            m_switches.at(switchVid)->onPostPortsCreate(1, &objectRid);
         }
     }
 
@@ -4021,6 +4025,25 @@ void Syncd::snoopGetOid(
     {
         // if snooped oid is NULL then we don't need take any action
         return;
+    }
+
+    /*
+     * Check if object was previously discovered on this switch, then no need to update ASIC_STATE.
+     */
+    if (!isInitViewMode())
+    {
+        sai_object_id_t rid;
+
+        if (m_translator->tryTranslateVidToRid(vid, rid))
+        {
+            const auto switchVid = VidManager::switchIdQuery(vid);
+
+            if (m_switches[switchVid]->isDiscoveredRid(rid))
+            {
+                // Already discovered object.
+                return;
+            }
+        }
     }
 
     /*

--- a/syncd/VirtualOidTranslator.cpp
+++ b/syncd/VirtualOidTranslator.cpp
@@ -147,6 +147,79 @@ sai_object_id_t VirtualOidTranslator::translateRidToVid(
     return vid;
 }
 
+void VirtualOidTranslator::translateRidsToVids(
+        _In_ sai_object_id_t switchVid,
+        _In_ size_t count,
+        _In_ const sai_object_id_t* rids,
+        _Out_ sai_object_id_t* vids)
+{
+    SWSS_LOG_ENTER();
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    /*
+     * Fetch VIDs for given RIDs from database.
+     * Unknown RID's will be mapped to SAI_NULL_OBJECT_ID in vids array.
+     */
+    m_client->getVidsForRids(count, rids, vids);
+
+    std::vector<sai_object_id_t> newRids;
+    std::vector<sai_object_id_t> newVids;
+    newRids.reserve(count);
+    newVids.reserve(count);
+
+    /*
+     * Get unknown (new) RIDs into newRids array.
+     */
+    for (size_t idx = 0; idx < count; idx++)
+    {
+        if (vids[idx] == SAI_NULL_OBJECT_ID)
+        {
+            newRids.push_back(rids[idx]);
+            newVids.push_back(SAI_NULL_OBJECT_ID);
+        }
+    }
+
+    const auto newOidsCount = newVids.size();
+
+    std::vector<sai_object_type_t> newObjectTypes(newOidsCount);
+
+    for (size_t idx = 0; idx < newOidsCount; idx++)
+    {
+        newObjectTypes[idx] = m_vendorSai->objectTypeQuery(newRids[idx]);
+    }
+
+    /*
+     * Allocate VIDs for new RIDs.
+     */
+    m_virtualObjectIdManager->allocateNewObjectIds(switchVid, newOidsCount, newObjectTypes.data(), newVids.data());
+
+    /*
+     * Insert VID and RID mappings into local and redis db.
+     */
+    m_client->insertVidsAndRids(newOidsCount, newVids.data(), newRids.data());
+
+    /*
+     * Replace VID's for new RIDs in output vids array and update local cache.
+     * Update each null VID in the output array with the corresponding newly allocated VID,
+     * preserving the same order to maintain correct RID-to-VID mapping.
+     */
+    for (size_t idx = 0, newIdx = 0; idx < count; idx++)
+    {
+        if (vids[idx] == SAI_NULL_OBJECT_ID)
+        {
+            vids[idx] = newVids[newIdx];
+            newIdx++;
+        }
+    }
+
+    for (size_t idx = 0; idx < count; idx++)
+    {
+        m_rid2vid[rids[idx]] = vids[idx];
+        m_vid2rid[vids[idx]] = rids[idx];
+    }
+}
+
 bool VirtualOidTranslator::checkRidExists(
         _In_ sai_object_id_t rid,
         _In_ bool checkRemoved)
@@ -541,6 +614,24 @@ void VirtualOidTranslator::insertRidAndVid(
     m_vid2rid[vid] = rid;
 
     m_client->insertVidAndRid(vid, rid);
+}
+
+void VirtualOidTranslator::insertRidsAndVids(
+        _In_ size_t count,
+        _In_ const sai_object_id_t* rids,
+        _In_ const sai_object_id_t* vids)
+{
+    SWSS_LOG_ENTER();
+
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    for (size_t idx = 0; idx < count; idx++)
+    {
+        m_rid2vid[rids[idx]] = vids[idx];
+        m_vid2rid[vids[idx]] = rids[idx];
+    }
+
+    m_client->insertVidsAndRids(count, vids, rids);
 }
 
 void VirtualOidTranslator::eraseRidAndVid(

--- a/syncd/VirtualOidTranslator.h
+++ b/syncd/VirtualOidTranslator.h
@@ -59,6 +59,16 @@ namespace syncd
                     _In_ bool translateRemoved = false);
 
             /*
+             * Translate RIDs to VIDs in batch, prefer this method when doing bulk operations,
+             * initial object discovery or when many objects need to be mapped to virtual IDs.
+             */
+            void translateRidsToVids(
+                    _In_ sai_object_id_t switchVid,
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* rids,
+                    _Out_ sai_object_id_t* vids);
+
+            /*
              * This method is required to translate RID to VIDs when we are doing
              * snoop for new ID's in init view mode, on in apply view mode when we
              * are executing GET api, and new object RIDs were spotted the we will
@@ -108,8 +118,13 @@ namespace syncd
                     _In_ sai_object_id_t vid);
 
             void insertRidAndVid(
-                    _In_ sai_object_id_t rid,
-                    _In_ sai_object_id_t vid);
+                    _In_ const sai_object_id_t rid,
+                    _In_ const sai_object_id_t vid);
+
+            void insertRidsAndVids(
+                    _In_ size_t count,
+                    _In_ const sai_object_id_t* rids,
+                    _In_ const sai_object_id_t* vids);
 
             void clearLocalCache();
 


### PR DESCRIPTION
The performance issue observed in port discovery part (as explained in #1416) addressed by optimizing discovery process. We get from 4.7 sec to 0.8 sec and pretty much bandwidth limited by redis-server performance (redis-benchmark shows 0.7 sec for 30K set operations).

Strategy:

Don't get SAI attributes on ports that are just created that have a known default null oid or empty list value Allocate VIDs for all discovered objects in one redis command INCRBY Use Redis pipeline for set operations